### PR TITLE
Add the ability to clone and read binary indexes to the C API.

### DIFF
--- a/c_api/clone_index_c.cpp
+++ b/c_api/clone_index_c.cpp
@@ -24,10 +24,12 @@ int faiss_clone_index(const FaissIndex* idx, FaissIndex** p_out) {
     CATCH_AND_HANDLE
 }
 
-
-int faiss_clone_index_binary(const FaissIndexBinary* idx, FaissIndexBinary** p_out) {
+int faiss_clone_index_binary(
+        const FaissIndexBinary* idx,
+        FaissIndexBinary** p_out) {
     try {
-        auto out = faiss::clone_binary_index(reinterpret_cast<const IndexBinary*>(idx));
+        auto out = faiss::clone_binary_index(
+                reinterpret_cast<const IndexBinary*>(idx));
         *p_out = reinterpret_cast<FaissIndexBinary*>(out);
     }
     CATCH_AND_HANDLE

--- a/c_api/clone_index_c.cpp
+++ b/c_api/clone_index_c.cpp
@@ -14,11 +14,21 @@
 #include "macros_impl.h"
 
 using faiss::Index;
+using faiss::IndexBinary;
 
 int faiss_clone_index(const FaissIndex* idx, FaissIndex** p_out) {
     try {
         auto out = faiss::clone_index(reinterpret_cast<const Index*>(idx));
         *p_out = reinterpret_cast<FaissIndex*>(out);
+    }
+    CATCH_AND_HANDLE
+}
+
+
+int faiss_clone_index_binary(const FaissIndexBinary* idx, FaissIndexBinary** p_out) {
+    try {
+        auto out = faiss::clone_binary_index(reinterpret_cast<const IndexBinary*>(idx));
+        *p_out = reinterpret_cast<FaissIndexBinary*>(out);
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/clone_index_c.h
+++ b/c_api/clone_index_c.h
@@ -13,8 +13,8 @@
 #define FAISS_CLONE_INDEX_C_H
 
 #include <stdio.h>
-#include "Index_c.h"
 #include "IndexBinary_c.h"
+#include "Index_c.h"
 #include "faiss_c.h"
 
 #ifdef __cplusplus

--- a/c_api/clone_index_c.h
+++ b/c_api/clone_index_c.h
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include "Index_c.h"
+#include "IndexBinary_c.h"
 #include "faiss_c.h"
 
 #ifdef __cplusplus
@@ -24,6 +25,9 @@ extern "C" {
 
 /** Clone an index. This is equivalent to `faiss::clone_index` */
 int faiss_clone_index(const FaissIndex*, FaissIndex** p_out);
+
+/** Clone a binary index. This is equivalent to `faiss::clone_index_binary` */
+int faiss_clone_index_binary(const FaissIndexBinary*, FaissIndexBinary** p_out);
 
 #ifdef __cplusplus
 }

--- a/c_api/index_factory_c.cpp
+++ b/c_api/index_factory_c.cpp
@@ -30,7 +30,6 @@ int faiss_index_factory(
     CATCH_AND_HANDLE
 }
 
-
 /** Build an index with the sequence of processing steps described in
  *  the string.
  */
@@ -39,8 +38,8 @@ int faiss_index_binary_factory(
         int d,
         const char* description) {
     try {
-        *p_index = reinterpret_cast<FaissIndexBinary*>(faiss::index_binary_factory(
-                d, description));
+        *p_index = reinterpret_cast<FaissIndexBinary*>(
+                faiss::index_binary_factory(d, description));
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/index_factory_c.cpp
+++ b/c_api/index_factory_c.cpp
@@ -15,7 +15,7 @@
 
 using faiss::Index;
 
-/** Build and index with the sequence of processing steps described in
+/** Build an index with the sequence of processing steps described in
  *  the string.
  */
 int faiss_index_factory(
@@ -26,6 +26,21 @@ int faiss_index_factory(
     try {
         *p_index = reinterpret_cast<FaissIndex*>(faiss::index_factory(
                 d, description, static_cast<faiss::MetricType>(metric)));
+    }
+    CATCH_AND_HANDLE
+}
+
+
+/** Build an index with the sequence of processing steps described in
+ *  the string.
+ */
+int faiss_index_binary_factory(
+        FaissIndexBinary** p_index,
+        int d,
+        const char* description) {
+    try {
+        *p_index = reinterpret_cast<FaissIndexBinary*>(faiss::index_binary_factory(
+                d, description));
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/index_factory_c.h
+++ b/c_api/index_factory_c.h
@@ -11,8 +11,8 @@
 #ifndef FAISS_INDEX_FACTORY_C_H
 #define FAISS_INDEX_FACTORY_C_H
 
-#include "Index_c.h"
 #include "IndexBinary_c.h"
+#include "Index_c.h"
 #include "faiss_c.h"
 
 #ifdef __cplusplus

--- a/c_api/index_factory_c.h
+++ b/c_api/index_factory_c.h
@@ -12,13 +12,14 @@
 #define FAISS_INDEX_FACTORY_C_H
 
 #include "Index_c.h"
+#include "IndexBinary_c.h"
 #include "faiss_c.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/** Build and index with the sequence of processing steps described in
+/** Build an index with the sequence of processing steps described in
  *  the string.
  */
 int faiss_index_factory(
@@ -26,6 +27,14 @@ int faiss_index_factory(
         int d,
         const char* description,
         FaissMetricType metric);
+
+/** Build a binary index with the sequence of processing steps described in
+ *  the string.
+ */
+int faiss_index_binary_factory(
+        FaissIndexBinary** p_index,
+        int d,
+        const char* description);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is in addition to Enet4/faiss-rs#79 which contains the faiss-sys related changes to consume these two functions and the rest of the C API for binary indexes.